### PR TITLE
add latent information return value and make drifts optional

### DIFF
--- a/driftbench/benchmarks/data.py
+++ b/driftbench/benchmarks/data.py
@@ -16,7 +16,7 @@ class Dataset:
         self.Y = transform_drift_segments_into_binary(drift_bounds, self.spec['N'])
 
     def _generate(self, random_state):
-        _, curves = sample_curves(
+        _, _, curves = sample_curves(
             dataset_specification=self.spec,
             f=self.f,
             w0=self.w0,

--- a/generate_datasets.py
+++ b/generate_datasets.py
@@ -14,6 +14,6 @@ if __name__ == '__main__':
 
         for dataset_name, spec in data_spec.items():
             print(datetime.now(), dataset_name)
-            w, curves = sample_curves(spec, f=None, random_state=10)
+            w, _, curves = sample_curves(spec, f=None, random_state=10)
             np.save(f'{dataset_name}.npy', curves)
             print(datetime.now())


### PR DESCRIPTION
# Done in this PR
- Drifts are now optional in a yaml specification when using the `sample_curves` function.
- The latent information used to sample the curves is now returned as additional return value.